### PR TITLE
Updating properties style to drop type when can be inferred easily.

### DIFF
--- a/unleash/src/main/java/com/silvercar/unleash/event/ToggleEvaluated.kt
+++ b/unleash/src/main/java/com/silvercar/unleash/event/ToggleEvaluated.kt
@@ -1,6 +1,6 @@
 package com.silvercar.unleash.event
 
-class ToggleEvaluated(
+data class ToggleEvaluated(
   val toggleName: String,
   val isEnabled: Boolean
 ) : UnleashEvent {

--- a/unleash/src/main/java/com/silvercar/unleash/metric/MetricsBucket.kt
+++ b/unleash/src/main/java/com/silvercar/unleash/metric/MetricsBucket.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.ConcurrentMap
 
 class MetricsBucket internal constructor() {
   @Transient private val calendar: Calendar = Calendar.getInstance(TimeZone.getTimeZone("GMT"))
-  val toggles: ConcurrentMap<String, ToggleCount> = ConcurrentHashMap()
+  val toggles = ConcurrentHashMap<String, ToggleCount>()
   val start: Date
 
   @Volatile var stop: Date? = null

--- a/unleash/src/main/java/com/silvercar/unleash/metric/ToggleCount.kt
+++ b/unleash/src/main/java/com/silvercar/unleash/metric/ToggleCount.kt
@@ -5,13 +5,13 @@ import java.util.concurrent.ConcurrentMap
 import java.util.concurrent.atomic.AtomicLong
 
 class ToggleCount {
-  private val _yes: AtomicLong = AtomicLong(0)
-  private val _no: AtomicLong = AtomicLong(0)
-  val variants: ConcurrentMap<String, AtomicLong?> = ConcurrentHashMap()
+  val variants = ConcurrentHashMap<String, AtomicLong?>()
 
+  private val _yes = AtomicLong(0)
   val yes: Long
     get() = _yes.get()
 
+  private val _no = AtomicLong(0)
   val no: Long
     get() = _no.get()
 

--- a/unleash/src/main/java/com/silvercar/unleash/metric/UnleashMetricsSender.kt
+++ b/unleash/src/main/java/com/silvercar/unleash/metric/UnleashMetricsSender.kt
@@ -1,6 +1,5 @@
 package com.silvercar.unleash.metric
 
-import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.silvercar.unleash.UnleashException
 import com.silvercar.unleash.event.EventDispatcher
@@ -13,17 +12,11 @@ import java.util.Date
 import java.util.concurrent.atomic.AtomicLong
 
 class UnleashMetricsSender(private val unleashConfig: UnleashConfig) {
-  private val gson: Gson = GsonBuilder()
-    .registerTypeAdapter(
-      Date::class.java,
-      DateSerializer()
-    )
-    .registerTypeAdapter(
-      AtomicLong::class.java,
-      AtomicLongSerializer()
-    )
+  private val gson = GsonBuilder()
+    .registerTypeAdapter(Date::class.java, DateSerializer())
+    .registerTypeAdapter(AtomicLong::class.java, AtomicLongSerializer())
     .create()
-  private val eventDispatcher: EventDispatcher = EventDispatcher(unleashConfig)
+  private val eventDispatcher = EventDispatcher(unleashConfig)
   private val clientRegistrationURL: URL = unleashConfig.unleashURLs.clientRegisterURL
   private val clientMetricsURL: URL = unleashConfig.unleashURLs.clientMetricsURL
 

--- a/unleash/src/main/java/com/silvercar/unleash/repository/FeatureToggleRepository.kt
+++ b/unleash/src/main/java/com/silvercar/unleash/repository/FeatureToggleRepository.kt
@@ -12,7 +12,7 @@ class FeatureToggleRepository(
   private val toggleFetcher: ToggleFetcher,
   private val toggleBackupHandler: ToggleBackupHandler
 ) : ToggleRepository {
-  private val eventDispatcher: EventDispatcher = EventDispatcher(unleashConfig)
+  private val eventDispatcher = EventDispatcher(unleashConfig)
   private var toggleCollection: ToggleCollection
   private var ready = false
 

--- a/unleash/src/main/java/com/silvercar/unleash/repository/GsonFactory.kt
+++ b/unleash/src/main/java/com/silvercar/unleash/repository/GsonFactory.kt
@@ -3,7 +3,7 @@ package com.silvercar.unleash.repository
 import com.google.gson.Gson
 
 object GsonFactory {
-  private val gson: Gson = Gson()
+  private val gson = Gson()
 
   fun getInstance(): Gson {
     return gson

--- a/unleash/src/main/java/com/silvercar/unleash/repository/HttpToggleFetcher.kt
+++ b/unleash/src/main/java/com/silvercar/unleash/repository/HttpToggleFetcher.kt
@@ -16,7 +16,7 @@ import kotlin.text.Charsets.UTF_8
 class HttpToggleFetcher(private val unleashConfig: UnleashConfig) : ToggleFetcher {
   private var eTag = ""
   private val toggleUrl: URL = unleashConfig.unleashURLs.fetchTogglesURL
-  private val jsonToggleParser: JsonToggleParser = JsonToggleParser()
+  private val jsonToggleParser = JsonToggleParser()
 
   @Throws(UnleashException::class)
   override fun fetchToggles(): FeatureToggleResponse {

--- a/unleash/src/main/java/com/silvercar/unleash/repository/JsonToggleParser.kt
+++ b/unleash/src/main/java/com/silvercar/unleash/repository/JsonToggleParser.kt
@@ -4,6 +4,7 @@ import java.io.Reader
 
 internal class JsonToggleParser {
   private val gsonFactory = GsonFactory
+
   fun toJsonString(toggleCollection: ToggleCollection?): String {
     return gsonFactory.getInstance().toJson(toggleCollection)
   }

--- a/unleash/src/main/java/com/silvercar/unleash/repository/ToggleBackupHandlerFile.kt
+++ b/unleash/src/main/java/com/silvercar/unleash/repository/ToggleBackupHandlerFile.kt
@@ -15,7 +15,7 @@ import java.io.IOException
 
 class ToggleBackupHandlerFile(config: UnleashConfig) : ToggleBackupHandler {
   private val backupFile: String = config.backupFile
-  private val eventDispatcher: EventDispatcher = EventDispatcher(config)
+  private val eventDispatcher = EventDispatcher(config)
 
   override fun read(): ToggleCollection {
     LOG.info("Unleash will try to load feature toggle states from temporary backup")

--- a/unleash/src/main/java/com/silvercar/unleash/variant/VariantDefinition.kt
+++ b/unleash/src/main/java/com/silvercar/unleash/variant/VariantDefinition.kt
@@ -14,7 +14,7 @@ data class VariantDefinition(
   val payload: Payload?,
   private val overrides: List<VariantOverride>?
 ) {
-  // TODO: Investigate why a Unit Test fails when this is a property
+  // Json can return overrides as null so this ensures safe access
   fun getOverrides(): List<VariantOverride> {
     return overrides ?: emptyList()
   }


### PR DESCRIPTION
#### Purpose
- [ ] Feature
- [ ] Bug Fix
- [X] Other

#### Details
- Removing property type when it is easy to ready the type inference.
- Moved backing properties next to the property that uses them.
- Changed ToggleEvaluated to the value object `data` class.
- Updated TODO to comment when discovered reason for using a function over property

#### Checklist
- [ ] Tests
