### PR TITLE
Removing Optional from Variant because not available to later Android APIs

### DIFF
--- a/unleash/src/main/java/com/silvercar/unleash/Variant.kt
+++ b/unleash/src/main/java/com/silvercar/unleash/Variant.kt
@@ -2,8 +2,6 @@ package com.silvercar.unleash
 
 import com.google.gson.annotations.SerializedName
 import com.silvercar.unleash.variant.Payload
-import java.util.Objects
-import java.util.Optional
 
 class Variant(
   val name: String,
@@ -17,8 +15,8 @@ class Variant(
     isEnabled: Boolean
   ) : this(name, Payload("string", payload), isEnabled)
 
-  fun getPayload(): Optional<Payload> {
-    return Optional.ofNullable(payload)
+  fun getPayload(): Payload? {
+    return payload
   }
 
   override fun toString(): String {

--- a/unleash/src/test/java/com/silvercar/unleash/UnleashTest.java
+++ b/unleash/src/test/java/com/silvercar/unleash/UnleashTest.java
@@ -13,7 +13,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import kotlin.jvm.functions.Function2;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -277,7 +276,7 @@ public class UnleashTest {
 
         assertThat(result, is(notNullValue()));
         assertThat(result.getName(), is("Chuck"));
-        assertThat(result.getPayload().map(Payload::getValue).get(), is("Norris"));
+        assertThat(result.getPayload().getValue(), is("Norris"));
         assertThat(result.isEnabled(), is(true));
     }
 
@@ -300,7 +299,7 @@ public class UnleashTest {
 
         assertThat(result, is(notNullValue()));
         assertThat(result.getName(), is("disabled"));
-        assertThat(result.getPayload().map(Payload::getValue), is(Optional.empty()));
+        assertNull(result.getPayload().getValue());
         assertThat(result.isEnabled(), is(false));
     }
 
@@ -323,7 +322,7 @@ public class UnleashTest {
 
         assertThat(result, is(notNullValue()));
         assertThat(result.getName(), is("en"));
-        assertThat(result.getPayload().map(Payload::getValue).get(), is("en"));
+        assertThat(result.getPayload().getValue(), is("en"));
         assertThat(result.isEnabled(), is(true));
     }
 
@@ -346,7 +345,7 @@ public class UnleashTest {
 
         assertThat(result, is(notNullValue()));
         assertThat(result.getName(), is("to"));
-        assertThat(result.getPayload().map(Payload::getValue).get(), is("to"));
+        assertThat(result.getPayload().getValue(), is("to"));
         assertThat(result.isEnabled(), is(true));
     }
 
@@ -365,7 +364,7 @@ public class UnleashTest {
 
         assertThat(result, is(notNullValue()));
         assertThat(result.getName(), is("disabled"));
-        assertThat(result.getPayload().map(Payload::getValue), is(Optional.empty()));
+        assertNull(result.getPayload().getValue());
         assertThat(result.isEnabled(), is(false));
     }
 
@@ -383,7 +382,7 @@ public class UnleashTest {
 
         assertThat(result, is(notNullValue()));
         assertThat(result.getName(), is("Chuck"));
-        assertThat(result.getPayload().map(Payload::getValue).get(), is("Norris"));
+        assertThat(result.getPayload().getValue(), is("Norris"));
         assertThat(result.isEnabled(), is(true));
     }
 
@@ -408,7 +407,7 @@ public class UnleashTest {
 
         assertThat(result, is(notNullValue()));
         assertThat(result.getName(), is("en"));
-        assertThat(result.getPayload().map(Payload::getValue).get(), is("en"));
+        assertThat(result.getPayload().getValue(), is("en"));
         assertThat(result.isEnabled(), is(true));
     }
 
@@ -433,7 +432,7 @@ public class UnleashTest {
 
         assertThat(result, is(notNullValue()));
         assertThat(result.getName(), is("to"));
-        assertThat(result.getPayload().map(Payload::getValue).get(), is("to"));
+        assertThat(result.getPayload().getValue(), is("to"));
         assertThat(result.isEnabled(), is(true));
     }
 

--- a/unleash/src/test/java/com/silvercar/unleash/variant/VariantUtilTest.java
+++ b/unleash/src/test/java/com/silvercar/unleash/variant/VariantUtilTest.java
@@ -48,7 +48,7 @@ public class VariantUtilTest {
         Variant variant = new VariantUtil().selectVariant(toggle, context, DISABLED_VARIANT);
 
         assertThat(variant.getName(), is(v1.getName()));
-        assertThat(variant.getPayload().get(), is(v1.getPayload()));
+        assertThat(variant.getPayload(), is(v1.getPayload()));
         assertThat(variant.isEnabled(), is(true));
     }
 
@@ -124,7 +124,7 @@ public class VariantUtilTest {
         Variant variant = new VariantUtil().selectVariant(toggle, context, DISABLED_VARIANT);
 
         assertThat(variant.getName(), is(v3.getName()));
-        assertThat(variant.getPayload().get(), is(v3.getPayload()));
+        assertThat(variant.getPayload(), is(v3.getPayload()));
         assertThat(variant.isEnabled(), is(true));
     }
 


### PR DESCRIPTION
#### Purpose
- [ ] Feature
- [ ] Bug Fix
- [X] Other

#### Details
Removing Optional from Variant because it isn't available in lower Android APIs that we are trying to support.

#### Checklist
- [ ] Tests
